### PR TITLE
Puppet lint run

### DIFF
--- a/manifests/command_check.pp
+++ b/manifests/command_check.pp
@@ -6,23 +6,23 @@ define prtg_push::command_check (
   $port,
   $token,
 ) {
-  file {"/opt/prtg_push/command_${title}.sh":
-    ensure   => present,
-    mode     => '700',
-    content  => epp('prtg_push/command_check.epp', {
-                  command        => $command,
-                  friendly_name  => $title,
-                  hostname       => $hostname,
-                  port           => $port,
-                  token          => $token,
+  file { "/opt/prtg_push/command_${title}.sh":
+    ensure  => present,
+    mode    => '0700',
+    content => epp('prtg_push/command_check.epp', {
+                  command       => $command,
+                  friendly_name => $title,
+                  hostname      => $hostname,
+                  port          => $port,
+                  token         => $token,
                 }),
-                
+
   }
 
   cron { "prtg_push_command_check_${title}":
-    command  => "bash -x /opt/prtg_push/command_${title}.sh",
-    user     => 'root',
-    hour     => $cron_hour,
-    minute   => $cron_minute,
+    command => "bash -x /opt/prtg_push/command_${title}.sh",
+    user    => 'root',
+    hour    => $cron_hour,
+    minute  => $cron_minute,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 class prtg_push {
   file {'/opt/prtg_push':
-    ensure  => directory,
-    purge   => true,
+    ensure => directory,
+    purge  => true,
   }
 }

--- a/manifests/newest_file.pp
+++ b/manifests/newest_file.pp
@@ -7,23 +7,23 @@ define prtg_push::newest_file (
   $port,
   $token,
 ) {
-  file {"/opt/prtg_push/newest_file_${title}.sh":
-    ensure   => present,
-    mode     => '700',
-    content  => epp('prtg_push/newest_file.epp', {
-                  file_ext   	 => $file_ext,
-                  check_dir      => $check_dir,
-                  hostname       => $hostname,
-                  port           => $port,
-                  token          => $token,
+  file { "/opt/prtg_push/newest_file_${title}.sh":
+    ensure  => present,
+    mode    => '0700',
+    content => epp('prtg_push/newest_file.epp', {
+                  file_ext  => $file_ext,
+                  check_dir => $check_dir,
+                  hostname  => $hostname,
+                  port      => $port,
+                  token     => $token,
                 }),
-                
+
   }
 
   cron { "prtg_push_newest_file_${title}":
-    command  => "bash -x /opt/prtg_push/newest_file_${title}.sh",
-    user     => 'root',
-    hour     => $cron_hour,
-    minute   => $cron_minute,
+    command => "bash -x /opt/prtg_push/newest_file_${title}.sh",
+    user    => 'root',
+    hour    => $cron_hour,
+    minute  => $cron_minute,
   }
 }

--- a/manifests/service_check.pp
+++ b/manifests/service_check.pp
@@ -1,28 +1,28 @@
 define prtg_push::service_check (
   $cron_hour    = '*',
   $cron_minute  = '*',
-  $service_name = "${title}",
+  $service_name = $title,
   $hostname,
   $port,
   $token,
 ) {
-  file {"/opt/prtg_push/service_${title}.sh":
-    ensure   => present,
-    mode     => '700',
-    content  => epp('prtg_push/service_check.epp', {
-                  service_name   => $service_name,
-                  friendly_name  => $title,
-                  hostname       => $hostname,
-                  port           => $port,
-                  token          => $token,
+  file { "/opt/prtg_push/service_${title}.sh":
+    ensure  => present,
+    mode    => '0700',
+    content => epp('prtg_push/service_check.epp', {
+                  service_name  => $service_name,
+                  friendly_name => $title,
+                  hostname      => $hostname,
+                  port          => $port,
+                  token         => $token,
                 }),
-                
+
   }
 
   cron { "prtg_push_service_check_${title}":
-    command  => "bash -x /opt/prtg_push/service_${title}.sh",
-    user     => 'root',
-    hour     => $cron_hour,
-    minute   => $cron_minute,
+    command => "bash -x /opt/prtg_push/service_${title}.sh",
+    user    => 'root',
+    hour    => $cron_hour,
+    minute  => $cron_minute,
   }
 }


### PR DESCRIPTION
This is running `puppet-lint -f manifests/` and some manual edits to fix spacing according to the style guide.