### PR TITLE
Specify SSL protocol

### DIFF
--- a/templates/command_check.epp
+++ b/templates/command_check.epp
@@ -12,5 +12,5 @@ COMMAND="<%= $command %>"
 OUTPUT=$(<%= $command %>)
 FRIENDLY="<%= $friendly_name %>"
 
-wget -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY}</channel><value>${OUTPUT}</value></result><text>${COMMAND}</text></prtg>"
+wget --secure-protocol=TLSv1_1 -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY}</channel><value>${OUTPUT}</value></result><text>${COMMAND}</text></prtg>"
 

--- a/templates/newest_file.epp
+++ b/templates/newest_file.epp
@@ -19,4 +19,4 @@ AGE=$((${TIME_NOW} - ${TIMESTAMP}))
 AGE_HOURS=$((${AGE}/60/60))
 SIZE="`du -m ${NEWEST_FILE} | awk '{print $1;}'`"
 
-wget -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>Age (Hours)</channel><value>${AGE_HOURS}</value></result><result><channel>Size (MB)</channel><value>${SIZE}</value></result><text>${NEWEST_FILE} details</text></prtg>"
+wget --secure-protocol=TLSv1_1 -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>Age (Hours)</channel><value>${AGE_HOURS}</value></result><result><channel>Size (MB)</channel><value>${SIZE}</value></result><text>${NEWEST_FILE} details</text></prtg>"

--- a/templates/service_check.epp
+++ b/templates/service_check.epp
@@ -14,8 +14,8 @@ FRIENDLY="<%= $friendly_name %>"
 if (( $(ps -ef | grep -v grep | grep "${SERVICE}" | wc -l) > 0 ))
   then
     # Send response to PRTG that the service is running.
-    wget -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY} status</channel><value>1</value></result><text>Service: ${FRIENDLY} is running!</text></prtg>"
+    wget --secure-protocol=TLSv1_1 -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY} status</channel><value>1</value></result><text>Service: ${FRIENDLY} is running!</text></prtg>"
   else
     # Send response to PRTG that the service is not running.
-    wget -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY} status</channel><value>0</value></result><text>Service: ${FRIENDLY} is down</text></prtg>"
+    wget --secure-protocol=TLSv1_1 -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY} status</channel><value>0</value></result><text>Service: ${FRIENDLY} is down</text></prtg>"
 fi


### PR DESCRIPTION
We're currently running into an issue where wget seems to be defaulting to SSL3 and failing:

```
root@backup-itops-prod-1:/opt/prtg_push# ./newest_file_hyperv_itbot2.sh
--2021-04-13 15:50:48--  https://prtg.it.puppet.net:9090/backup-itops-prod-1.it.puppet.net-hyperv_itbot2?content=%3Cprtg%3E%3Cresult%3E%3Cchannel%3EAge%20(Hours)%3C/channel%3E%3Cvalue%3E9%3C/value%3E%3C/result%3E%3Cresult%3E%3Cchannel%3ESize%20(MB)%3C/channel%3E%3Cvalue%3E18274%3C/value%3E%3C/result%3E%3Ctext%3E/opt/backup_landing/hyperv/itbot-prod-2.it.puppet.net.qcow2.gpg%20details%3C/text%3E%3C/prtg%3E
Resolving prtg.it.puppet.net (prtg.it.puppet.net)... 10.64.4.42
Connecting to prtg.it.puppet.net (prtg.it.puppet.net)|10.64.4.42|:9090... connected.
OpenSSL: error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure
Unable to establish SSL connection.
```

However, this seems to be resolved when specifying a TLS protocol (though anything >TLS 1.1 does not appear to work)