### PR TITLE
Rolls back SSL protocol addition, simplifies Bash conditional

### DIFF
--- a/templates/command_check.epp
+++ b/templates/command_check.epp
@@ -4,6 +4,7 @@
       String   $command,
       String   $friendly_name,
 | -%>
+#!/bin/bash
 
 HOST="<%= $hostname %>"
 PORT="<%= $port %>"

--- a/templates/command_check.epp
+++ b/templates/command_check.epp
@@ -13,5 +13,5 @@ COMMAND="<%= $command %>"
 OUTPUT=$(<%= $command %>)
 FRIENDLY="<%= $friendly_name %>"
 
-wget --secure-protocol=TLSv1_1 -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY}</channel><value>${OUTPUT}</value></result><text>${COMMAND}</text></prtg>"
+wget -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY}</channel><value>${OUTPUT}</value></result><text>${COMMAND}</text></prtg>"
 

--- a/templates/newest_file.epp
+++ b/templates/newest_file.epp
@@ -4,6 +4,7 @@
       String   $file_ext,
       String   $check_dir,
 | -%>
+#!/bin/bash
 
 HOST="<%= $hostname %>"
 PORT="<%= $port %>"

--- a/templates/newest_file.epp
+++ b/templates/newest_file.epp
@@ -20,4 +20,4 @@ AGE=$((${TIME_NOW} - ${TIMESTAMP}))
 AGE_HOURS=$((${AGE}/60/60))
 SIZE="`du -m ${NEWEST_FILE} | awk '{print $1;}'`"
 
-wget --secure-protocol=TLSv1_1 -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>Age (Hours)</channel><value>${AGE_HOURS}</value></result><result><channel>Size (MB)</channel><value>${SIZE}</value></result><text>${NEWEST_FILE} details</text></prtg>"
+wget -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>Age (Hours)</channel><value>${AGE_HOURS}</value></result><result><channel>Size (MB)</channel><value>${SIZE}</value></result><text>${NEWEST_FILE} details</text></prtg>"

--- a/templates/service_check.epp
+++ b/templates/service_check.epp
@@ -4,6 +4,7 @@
       String   $service_name,
       String   $friendly_name,
 | -%>
+#!/bin/bash
 
 HOST="<%= $hostname %>"
 PORT="<%= $port %>"

--- a/templates/service_check.epp
+++ b/templates/service_check.epp
@@ -15,8 +15,8 @@ FRIENDLY="<%= $friendly_name %>"
 if (( $(ps -ef | grep -v grep | grep "${SERVICE}" | wc -l) > 0 ))
   then
     # Send response to PRTG that the service is running.
-    wget --secure-protocol=TLSv1_1 -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY} status</channel><value>1</value></result><text>Service: ${FRIENDLY} is running!</text></prtg>"
+    wget -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY} status</channel><value>1</value></result><text>Service: ${FRIENDLY} is running!</text></prtg>"
   else
     # Send response to PRTG that the service is not running.
-    wget --secure-protocol=TLSv1_1 -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY} status</channel><value>0</value></result><text>Service: ${FRIENDLY} is down</text></prtg>"
+    wget -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY} status</channel><value>0</value></result><text>Service: ${FRIENDLY} is down</text></prtg>"
 fi

--- a/templates/service_check.epp
+++ b/templates/service_check.epp
@@ -12,7 +12,7 @@ TOKEN="<%= $token %>"
 SERVICE="<%= $service_name %>"
 FRIENDLY="<%= $friendly_name %>"
 
-if (( $(ps -ef | grep -v grep | grep "${SERVICE}" | wc -l) > 0 ))
+if pgrep -f "${SERVICE}" ;
   then
     # Send response to PRTG that the service is running.
     wget -O/dev/null "https://${HOST}:${PORT}/${TOKEN}?content=<prtg><result><channel>${FRIENDLY} status</channel><value>1</value></result><text>Service: ${FRIENDLY} is running!</text></prtg>"


### PR DESCRIPTION
This does a few things:

- Adds a shebang to the script templates to be explicit about the shell they should run in
- Removes the SSL protocol specification from the wget command, which was an attempt to fix the PRTG cert issue yesterday but not really needed
- Simplifies the Bash conditional for the service check.

I tested his on the BFS VPN server, and the conditional stuff works as expected:

```
root@vpn-bfs-corp-prod-1:/opt/prtg_push# pgrep -f ovpn-openvpn_corp_udp
32189
root@vpn-bfs-corp-prod-1:/opt/prtg_push# echo $?
0
root@vpn-bfs-corp-prod-1:/opt/prtg_push# pgrep -f slapd
root@vpn-bfs-corp-prod-1:/opt/prtg_push# echo $?
1
```

I also manually edited the script and ran it, got green in PRTG \o/